### PR TITLE
Allow accessing refcount property of keyword and prefix search results

### DIFF
--- a/dbpedia.gemspec
+++ b/dbpedia.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
   s.name          = 'dbpedia'
-  s.version       = '0.0.1'
+  s.version       = '0.0.2'
   s.summary       = 'DBpedia Client for Ruby'
   s.description   = 'Simple search for DBpedia resources. Optional support for sparql.'
 

--- a/lib/dbpedia/search_result.rb
+++ b/lib/dbpedia/search_result.rb
@@ -5,10 +5,11 @@ module Dbpedia
     require 'dbpedia/search_result/category'
     require 'dbpedia/search_result/klass'
 
-    attr_accessor :label, :uri, :description, :label, :categories, :classes
+    attr_accessor :refcount, :label, :uri, :description, :label, :categories, :classes
 
     def parse
       self.tap do |obj|
+        obj.label = read '> RefCount'
         obj.label = read '> Label'
         obj.uri = read '> URI'
         obj.description = read '> Description'


### PR DESCRIPTION
The services use RefCount property to rank search results. 